### PR TITLE
move tox requirement to development.txt

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -6,3 +6,4 @@
 wheel
 pre-commit
 twine
+tox

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,5 +2,4 @@
 -r common.txt
 pytest
 pytest-cov
-tox
 selenium==3.141.0


### PR DESCRIPTION
- Add `tox` in `development.txt`, which is needed for people who contribute to the docs to test it on their machine.