### PR TITLE
fix newer dataverse compatibility by adding content-type=application/json header

### DIFF
--- a/src/pyDataverse/api.py
+++ b/src/pyDataverse/api.py
@@ -140,7 +140,7 @@ class Api:
                 "ERROR: GET - Could not establish connection to api {0}.".format(url)
             )
 
-    def post_request(self, url, data=None, auth=False, params=None, files=None):
+    def post_request(self, url, data=None, auth=False, params=None, files=None, content_type=None):
         """Make a POST request.
 
         params will be added as key-value pairs to the URL.
@@ -158,6 +158,9 @@ class Api:
         params : dict
             Dictionary of parameters to be passed with the request.
             Defaults to `None`.
+        content_type : str
+            Content-type to send the POST with
+            Defaults to `None`.
 
         Returns
         -------
@@ -170,8 +173,13 @@ class Api:
         if self.api_token:
             params["key"] = self.api_token
 
+        if content_type:
+                kwargs = {"headers": {"content-type": content_type}}
+        else:
+                kwargs = {}
+
         try:
-            resp = post(url, data=data, params=params, files=files)
+            resp = post(url, data=data, params=params, files=files, **kwargs)
             if resp.status_code == 401:
                 error_msg = resp.json()["message"]
                 raise ApiAuthorizationError(
@@ -1196,7 +1204,7 @@ class NativeApi(Api):
             url = "{0}/dataverses/{1}/datasets".format(
                 self.base_url_api_native, dataverse
             )
-        resp = self.post_request(url, metadata, auth)
+        resp = self.post_request(url, metadata, auth, content_type="application/json")
 
         if resp.status_code == 404:
             error_msg = resp.json()["message"]


### PR DESCRIPTION
fix newer dataverse compatibility by adding content-type=application/json header

Changes:
 - able to add content-type parameter to post_request()
 - set content-type to application/json for strings in

based on https://github.com/JR-1991/pyDataverse/commit/0fcfcd3fbc6bf1aec869899f715a51dca25e91be

* [ ] OS: Linux, Debian 10, 64bit
* [ ] pyDataverse: 0.3.1
* [ ] Python: 3.9.2
* [ ] Dataverse: 5.10.1

Closes #143 
