### PR TITLE
fix broken link in API reference #147

### DIFF
--- a/src/pyDataverse/api.py
+++ b/src/pyDataverse/api.py
@@ -1249,7 +1249,7 @@ class NativeApi(Api):
         For these edits your JSON file need only include those dataset fields
         which you would like to edit. A sample JSON file may be downloaded
         here: `dataset-edit-metadata-sample.json
-        <http://guides.dataverse.org/en/latest/_downloads/dataset-finch1.json>`_
+        <https://guides.dataverse.org/en/5.11/_downloads/cb0fae993277527ea354dc15bc5db864/dataset-edit-metadata-sample.json>`_
 
         Parameters
         ----------


### PR DESCRIPTION
- Closes #147

Note that I'm linking to 5.11 because I don't know how stable the equivalent link (to the right JSON file) under "latest" is.