### PR TITLE
Add CI/CD pipeline and re-establish existing tests

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -4,7 +4,7 @@ on: [push]
 jobs:
   custom_test:
     runs-on: ubuntu-latest
-    name: Test PyDtaverse
+    name: Test pyDataverse
     env:
       PORT: 8080
     steps:

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -27,5 +27,6 @@ jobs:
           API_TOKEN_SUPERUSER: ${{ steps.dataverse.outputs.api_token }}
           API_TOKEN: ${{ steps.dataverse.outputs.api_token }}
           BASE_URL: ${{ steps.dataverse.outputs.base_url }}
+          DV_VERSION: "6.0"
         run: |
           python3 -m pytest

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,10 +1,10 @@
-name: Test PyDataverse
+name: Unit tests
 on: [push]
 
 jobs:
   custom_test:
     runs-on: ubuntu-latest
-    name: Test Dataverse Action
+    name: Test PyDtaverse
     env:
       PORT: 8080
     steps:
@@ -21,6 +21,7 @@ jobs:
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install -r ./requirements/tests.txt
+          pip install -e .
       - name: Run tests
         env:
           API_TOKEN: ${{ steps.dataverse.outputs.api_token }}

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -24,6 +24,7 @@ jobs:
           pip install -e .
       - name: Run tests
         env:
+          API_TOKEN_SUPERUSER: ${{ steps.dataverse.outputs.api_token }}
           API_TOKEN: ${{ steps.dataverse.outputs.api_token }}
           BASE_URL: ${{ steps.dataverse.outputs.base_url }}
         run: |

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -27,6 +27,6 @@ jobs:
           API_TOKEN_SUPERUSER: ${{ steps.dataverse.outputs.api_token }}
           API_TOKEN: ${{ steps.dataverse.outputs.api_token }}
           BASE_URL: ${{ steps.dataverse.outputs.base_url }}
-          DV_VERSION: "6.0"
+          DV_VERSION: ${{ steps.dataverse.outputs.dv_version }}
         run: |
           python3 -m pytest

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -1,0 +1,29 @@
+name: Test PyDataverse
+on: [push]
+
+jobs:
+  custom_test:
+    runs-on: ubuntu-latest
+    name: Test Dataverse Action
+    env:
+      PORT: 8080
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+      - name: Run Dataverse Action
+        id: dataverse
+        uses: gdcc/dataverse-action@test-action
+      - name: Setup Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - name: Install Python Dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -r ./requirements/tests.txt
+      - name: Run tests
+        env:
+          API_TOKEN: ${{ steps.dataverse.outputs.api_token }}
+          BASE_URL: ${{ steps.dataverse.outputs.base_url }}
+        run: |
+          python3 -m pytest

--- a/src/pyDataverse/api.py
+++ b/src/pyDataverse/api.py
@@ -1,6 +1,7 @@
 """Dataverse API wrapper for all it's API's."""
 import json
 import subprocess as sp
+from urllib.parse import urljoin
 
 from requests import ConnectionError, Response, delete, get, post, put
 
@@ -118,6 +119,7 @@ class Api:
             params["key"] = str(self.api_token)
 
         try:
+            url = urljoin(self.base_url_api, url)
             resp = get(url, params=params)
             if resp.status_code == 401:
                 error_msg = resp.json()["message"]

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -25,9 +25,9 @@ class TestApiConnect(object):
         assert isinstance(native_api, NativeApi)
         assert not native_api.api_token
         assert native_api.api_version == "v1"
-        assert native_api.base_url == os.getenv("BASE_URL")
+        assert native_api.base_url == os.getenv("BASE_URL").rstrip("/")
         assert native_api.base_url_api_native == "{0}/api/{1}".format(
-            os.getenv("BASE_URL"), native_api.api_version
+            os.getenv("BASE_URL").rstrip("/"), native_api.api_version
         )
 
     def test_api_connect_base_url_wrong(self):
@@ -51,7 +51,7 @@ class TestApiRequests(object):
     def test_get_request(self, native_api):
         """Test successfull `.get_request()` request."""
         # TODO: test params und auth default
-        base_url = os.getenv("BASE_URL")
+        base_url = os.getenv("BASE_URL").rstrip("/")
         query_str = base_url + "/api/v1/info/server"
         resp = native_api.get_request(query_str)
         sleep(test_config["wait_time"])
@@ -72,11 +72,11 @@ if not os.environ.get("TRAVIS"):
         """Test user rights."""
 
         def test_token_missing(self):
-            BASE_URL = os.getenv("BASE_URL")
+            BASE_URL = os.getenv("BASE_URL").rstrip("/")
             api = NativeApi(BASE_URL)
             resp = api.get_info_version()
-            assert resp.json()["data"]["version"] == "4.18.1"
-            assert resp.json()["data"]["build"] == "267-a91d370"
+            assert resp.json()["data"]["version"] == os.getenv("DV_VERSION")
+            # assert resp.json()["data"]["build"] == "267-a91d370"
 
             with pytest.raises(ApiAuthorizationError):
                 ds = Dataset()
@@ -90,11 +90,11 @@ if not os.environ.get("TRAVIS"):
                 api.create_dataset(":root", ds.json())
 
         def test_token_empty_string(self):
-            BASE_URL = os.getenv("BASE_URL")
+            BASE_URL = os.getenv("BASE_URL").rstrip("/")
             api = NativeApi(BASE_URL, "")
             resp = api.get_info_version()
-            assert resp.json()["data"]["version"] == "4.18.1"
-            assert resp.json()["data"]["build"] == "267-a91d370"
+            assert resp.json()["data"]["version"] == os.getenv("DV_VERSION")
+            # assert resp.json()["data"]["build"] == "267-a91d370"
 
             with pytest.raises(ApiAuthorizationError):
                 ds = Dataset()
@@ -112,7 +112,7 @@ if not os.environ.get("TRAVIS"):
         #     API_TOKEN = os.getenv("API_TOKEN_NO_RIGHTS")
         #     api = NativeApi(BASE_URL, API_TOKEN)
         #     resp = api.get_info_version()
-        #     assert resp.json()["data"]["version"] == "4.18.1"
+        #     assert resp.json()["data"]["version"] == os.getenv("DV_VERSION")
         #     assert resp.json()["data"]["build"] == "267-a91d370"
 
         #     with pytest.raises(ApiAuthorizationError):
@@ -127,15 +127,15 @@ if not os.environ.get("TRAVIS"):
         #         api.create_dataset(":root", ds.json())
 
         def test_token_right_create_dataset_rights(self):
-            BASE_URL = os.getenv("BASE_URL")
+            BASE_URL = os.getenv("BASE_URL").rstrip("/")
             api_su = NativeApi(BASE_URL, os.getenv("API_TOKEN_SUPERUSER"))
             api_nru = NativeApi(BASE_URL, os.getenv("API_TOKEN_TEST_NO_RIGHTS"))
 
             resp = api_su.get_info_version()
-            assert resp.json()["data"]["version"] == "4.18.1"
-            assert resp.json()["data"]["build"] == "267-a91d370"
+            assert resp.json()["data"]["version"] == os.getenv("DV_VERSION")
+            # assert resp.json()["data"]["build"] == "267-a91d370"
             # resp = api_nru.get_info_version()
-            # assert resp.json()["data"]["version"] == "4.18.1"
+            # assert resp.json()["data"]["version"] == os.getenv("DV_VERSION")
             # assert resp.json()["data"]["build"] == "267-a91d370"
 
             ds = Dataset()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,8 +85,11 @@ def native_api(monkeypatch):
         Api object.
 
     """
-    monkeypatch.setenv("BASE_URL", "https://demo.dataverse.org")
-    return NativeApi(os.getenv("BASE_URL"))
+
+    BASE_URL = os.getenv("BASE_URL")
+
+    monkeypatch.setenv("BASE_URL", BASE_URL)
+    return NativeApi(BASE_URL)
 
 
 def import_dataverse_min_dict():
@@ -132,7 +135,10 @@ def import_datafile_min_dict():
         Minimum Datafile metadata.
 
     """
-    return {"pid": "doi:10.11587/EVMUHP", "filename": "tests/data/datafile.txt"}
+    return {
+        "pid": "doi:10.11587/EVMUHP",
+        "filename": "tests/data/datafile.txt",
+    }
 
 
 def import_datafile_full_dict():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,7 +65,7 @@ def test_config():
         "invalid_json_strings": invalid_filename_strings,
         "invalid_data_format_types": invalid_filename_types,
         "invalid_data_format_strings": invalid_filename_strings,
-        "base_url": os.getenv("BASE_URL"),
+        "base_url": os.getenv("BASE_URL").rstrip("/"),
         "api_token": os.getenv("API_TOKEN"),
         "travis": os.getenv("TRAVIS") or False,
         "wait_time": 1,
@@ -86,7 +86,7 @@ def native_api(monkeypatch):
 
     """
 
-    BASE_URL = os.getenv("BASE_URL")
+    BASE_URL = os.getenv("BASE_URL").rstrip("/")
 
     monkeypatch.setenv("BASE_URL", BASE_URL)
     return NativeApi(BASE_URL)


### PR DESCRIPTION
**Describe your environment**

* [x] pyDataverse: 0.3.1 <!-- (e. g. 0.2.1) -->
* [x] Python: 3.10 <!-- (e. g. 3.6.9) -->
* [x] Dataverse: 6.0 <!-- (optional, e. g. 4.18.1) -->

**Describe the PR**

* [x] What kind of change does this PR introduce?
  * CI/CD pipeline to test pyDataverse using the [dataverse-action](https://github.com/gdcc/dataverse-action/tree/test-action)
  * Minor changes to fetching Dataverse action outputs for testing
* [x] Why is this change required? What problem does it solve?
  * Re-establish the existing testing framework

**Testing**

* [x] Have you used tox and/or pytest for testing the changes?
* [x] Did the local testing ran successfully?
* [x] Did the Continous Integration testing (GitHub Action) ran successfully?

**Others**

* [x] Is there anything you need from someone else?

* @pdurbin @poikilotherm current the action only tests against the current version `6.0`, but this pipeline should check multiple versions. @skasberger proposed to test from 5.x on. Hence, we need to extend the dataverse action.
* Tests are running exclusively for `3.10` but will extend to other versions in the progress of this PR. Does `>3.7`seem reasonable? 
