### PR TITLE
Async requests

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,2 +1,3 @@
 httpx>=0.26.0
 jsonschema>=3.2.0
+urllib3>=2.2.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,5 +2,6 @@
 -r common.txt
 pytest
 pytest-cov
+pytest-asyncio
 tox
 selenium==3.141.0

--- a/src/pyDataverse/api.py
+++ b/src/pyDataverse/api.py
@@ -40,7 +40,7 @@ class Api:
     def __init__(
         self,
         base_url: str,
-        api_token: str = None,
+        api_token: Optional[str] = None,
         api_version: str = "latest",
     ):
         """Init an Api() class.

--- a/src/pyDataverse/api.py
+++ b/src/pyDataverse/api.py
@@ -1,6 +1,7 @@
 """Dataverse API wrapper for all it's API's."""
 
 import json
+from typing import Any, Dict, Optional
 import httpx
 import subprocess as sp
 from urllib.parse import urljoin
@@ -37,7 +38,10 @@ class Api:
     """
 
     def __init__(
-        self, base_url: str, api_token: str = None, api_version: str = "latest"
+        self,
+        base_url: str,
+        api_token: str = None,
+        api_version: str = "latest",
     ):
         """Init an Api() class.
 
@@ -64,6 +68,7 @@ class Api:
             raise ApiUrlError("base_url {0} is not a string.".format(base_url))
 
         self.base_url = base_url
+        self.client = None
 
         if not isinstance(api_version, ("".__class__, "".__class__)):
             raise ApiUrlError("api_version {0} is not a string.".format(api_version))
@@ -120,28 +125,17 @@ class Api:
         if self.api_token:
             params["key"] = str(self.api_token)
 
-        try:
-            url = urljoin(self.base_url_api, url)
-            resp = httpx.get(url, params=params)
-            if resp.status_code == 401:
-                error_msg = resp.json()["message"]
-                raise ApiAuthorizationError(
-                    "ERROR: GET - Authorization invalid {0}. MSG: {1}.".format(
-                        url, error_msg
-                    )
-                )
-            elif resp.status_code >= 300:
-                if resp.text:
-                    error_msg = resp.text
-                    raise OperationFailedError(
-                        "ERROR: GET HTTP {0} - {1}. MSG: {2}".format(
-                            resp.status_code, url, error_msg
-                        )
-                    )
-            return resp
-        except ConnectError:
-            raise ConnectError(
-                "ERROR: GET - Could not establish connection to api {0}.".format(url)
+        if self.client is None:
+            return self._sync_request(
+                method=httpx.get,
+                url=url,
+                params=params,
+            )
+        else:
+            return self._async_request(
+                method=self.client.get,
+                url=url,
+                params=params,
             )
 
     def post_request(self, url, data=None, auth=False, params=None, files=None):
@@ -174,19 +168,21 @@ class Api:
         if self.api_token:
             params["key"] = self.api_token
 
-        try:
-            resp = httpx.post(url, data=data, params=params, files=files)
-            if resp.status_code == 401:
-                error_msg = resp.json()["message"]
-                raise ApiAuthorizationError(
-                    "ERROR: POST HTTP 401 - Authorization error {0}. MSG: {1}".format(
-                        url, error_msg
-                    )
-                )
-            return resp
-        except ConnectError:
-            raise ConnectError(
-                "ERROR: POST - Could not establish connection to API: {0}".format(url)
+        if self.client is None:
+            return self._sync_request(
+                method=httpx.post,
+                url=url,
+                data=data,
+                params=params,
+                files=files,
+            )
+        else:
+            return self._async_request(
+                method=self.client.post,
+                url=url,
+                data=data,
+                params=params,
+                files=files,
             )
 
     def put_request(self, url, data=None, auth=False, params=None):
@@ -215,19 +211,19 @@ class Api:
         if self.api_token:
             params["key"] = self.api_token
 
-        try:
-            resp = httpx.put(url, data=data, params=params)
-            if resp.status_code == 401:
-                error_msg = resp.json()["message"]
-                raise ApiAuthorizationError(
-                    "ERROR: PUT HTTP 401 - Authorization error {0}. MSG: {1}".format(
-                        url, error_msg
-                    )
-                )
-            return resp
-        except ConnectError:
-            raise ConnectError(
-                "ERROR: PUT - Could not establish connection to api '{0}'.".format(url)
+        if self.client is None:
+            return self._sync_request(
+                method=httpx.put,
+                url=url,
+                data=data,
+                params=params,
+            )
+        else:
+            return self._async_request(
+                method=self.client.put,
+                url=url,
+                data=data,
+                params=params,
             )
 
     def delete_request(self, url, auth=False, params=None):
@@ -254,12 +250,76 @@ class Api:
         if self.api_token:
             params["key"] = self.api_token
 
+        if self.client is None:
+            return self._sync_request(
+                method=httpx.delete,
+                url=url,
+                params=params,
+            )
+        else:
+            return self._async_request(
+                method=self.client.delete,
+                url=url,
+                params=params,
+            )
+
+    def _sync_request(
+        self,
+        method,
+        **kwargs,
+    ):
+        assert "url" in kwargs, "URL is required for a request."
+
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
         try:
-            return httpx.delete(url, params=params)
+            resp = method(**kwargs)
+
+            if resp.status_code == 401:
+                error_msg = resp.json()["message"]
+                raise ApiAuthorizationError(
+                    "ERROR: HTTP 401 - Authorization error {0}. MSG: {1}".format(
+                        kwargs["url"], error_msg
+                    )
+                )
+
+            return resp
+
         except ConnectError:
             raise ConnectError(
-                "ERROR: DELETE could not establish connection to api {}.".format(url)
+                "ERROR - Could not establish connection to api '{0}'.".format(
+                    kwargs["url"]
+                )
             )
+
+    async def _async_request(
+        self,
+        method,
+        **kwargs,
+    ):
+        return await method(**kwargs)
+
+    async def __aenter__(self):
+        """
+        Context manager method that initializes an instance of httpx.AsyncClient.
+
+        Returns:
+            httpx.AsyncClient: An instance of httpx.AsyncClient.
+        """
+        self.client = httpx.AsyncClient()
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        """
+        Closes the client connection when exiting a context manager.
+
+        Args:
+            exc_type (type): The type of the exception raised, if any.
+            exc_value (Exception): The exception raised, if any.
+            traceback (traceback): The traceback object associated with the exception, if any.
+        """
+
+        await self.client.aclose()
+        self.client = None
 
 
 class DataAccessApi(Api):

--- a/tests/api/test_async_api.py
+++ b/tests/api/test_async_api.py
@@ -1,8 +1,6 @@
 import asyncio
 import pytest
 
-from pyDataverse.api import NativeApi
-
 
 class TestAsyncAPI:
 

--- a/tests/api/test_async_api.py
+++ b/tests/api/test_async_api.py
@@ -1,0 +1,18 @@
+import asyncio
+import pytest
+
+from pyDataverse.api import NativeApi
+
+
+class TestAsyncAPI:
+
+    @pytest.mark.asyncio
+    async def test_async_api(self, native_api):
+
+        async with native_api:
+            tasks = [native_api.get_info_version() for _ in range(10)]
+            responses = await asyncio.gather(*tasks)
+
+        assert len(responses) == 10
+        for response in responses:
+            assert response.status_code == 200, "Request failed."


### PR DESCRIPTION
**Changes this PR introduces**

This pull request adds async support to pyDataverse based on the previously merged switch from `requests` to `httpx`. Asynchronous requests significantly improve pyDataverse's performance by using concurrent requests. The implementation provides a seamless usage to work either sync or async by the usage of a context manager.

_Small benchmark_

* 100 calls to `api/info/version` to [demo.dataverse.org](demo.dataverse.org)
* Synchronous --> ~35s
* Asynchronous --> ~0.5s 🏎️

**Overview**

* Added `_sync_request` and `_async_request` base methods
* Added Context manager to `API` to enable async requests
* Small test to verify async requests are working

**Example**

_Synchronous_

```python
native_api = NativeApi("https://demo.dataverse.org")
response = native_api.get_info_version()
```

_Asynchronous_

```python
import asyncio
from pyDataverse.api import NativeApi


async def run_async(native_api):
    async with native_api:
        tasks = [native_api.get_info_version() for _ in range(100)]
        responses = await asyncio.gather(*tasks)

if __name__ == "__main__":
    native_api = NativeApi("https://demo.dataverse.org")
    asyncio.run(run_async(native_api))
```