### PR TITLE
Update Docs Occurrences of requests.Response

### DIFF
--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -51,11 +51,11 @@ class Api:
         ----------
         base_url : str
             Base url for Dataverse api.
-        api_token : str
+        api_token : str | None
             Api token for Dataverse api.
 
         Examples
-        -------
+        --------
         Create an Api connection::
 
             >>> from pyDataverse.api import Api
@@ -115,8 +115,8 @@ class Api:
 
         Returns
         -------
-        class:`requests.Response`
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         params = {}
@@ -150,16 +150,16 @@ class Api:
             Metadata as a json-formatted string. Defaults to `None`.
         auth : bool
             Should an api token be sent in the request. Defaults to `False`.
-        files: dict
-            e. g. files = {'file': open('sample_file.txt','rb')}
+        files : dict
+            e.g. :code:`files={'file': open('sample_file.txt','rb')}`
         params : dict
             Dictionary of parameters to be passed with the request.
-            Defaults to `None`.
+            Defaults to :code:`None`.
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         params = {}
@@ -204,8 +204,8 @@ class Api:
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         params = {}
@@ -246,8 +246,8 @@ class Api:
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         params = {}
@@ -281,7 +281,7 @@ class Api:
             **kwargs: Additional keyword arguments to be passed to the method.
 
         Returns:
-            requests.Response: The response object returned by the request.
+            httpx.Response: The response object returned by the request.
 
         Raises:
             ApiAuthorizationError: If the response status code is 401 (Authorization error).
@@ -393,12 +393,6 @@ class Api:
 class DataAccessApi(Api):
     """Class to access Dataverse's Data Access API.
 
-    Examples
-    -------
-    Examples should be written in doctest format, and
-    should illustrate how to use the function/class.
-    >>>
-
     Attributes
     ----------
     base_url_api_data_access : type
@@ -460,8 +454,8 @@ class DataAccessApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         is_first_param = True
@@ -506,8 +500,8 @@ class DataAccessApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/datafiles/{1}".format(self.base_url_api_data_access, identifier)
@@ -547,8 +541,8 @@ class DataAccessApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/datafile/bundle/{1}".format(
@@ -794,8 +788,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/dataverses/{1}".format(self.base_url_api_native, identifier)
@@ -835,8 +829,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         metadata_dict = json.loads(metadata)
@@ -887,8 +881,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/dataverses/{1}/actions/:publish".format(
@@ -935,8 +929,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/dataverses/{1}".format(self.base_url_api_native, identifier)
@@ -991,8 +985,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/dataverses/{1}/roles".format(self.base_url_api_native, identifier)
@@ -1011,8 +1005,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/dataverses/{1}/contents".format(self.base_url_api_native, identifier)
@@ -1035,8 +1029,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/dataverses/{1}/assignments".format(
@@ -1061,8 +1055,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/dataverses/{1}/facets".format(self.base_url_api_native, identifier)
@@ -1123,8 +1117,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         if is_pid:
@@ -1162,8 +1156,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         if is_pid:
@@ -1203,8 +1197,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         if is_pid:
@@ -1237,8 +1231,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/datasets/export?exporter={1}&persistentId={2}".format(
@@ -1311,8 +1305,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         if pid:
@@ -1399,8 +1393,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         Examples
         -------
@@ -1561,8 +1555,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/datasets/:persistentId/actions/:publish".format(
@@ -1601,8 +1595,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/datasets/:persistentId/locks/?persistentId={1}".format(
@@ -1645,8 +1639,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         if is_pid:
@@ -1737,8 +1731,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         base_str = "{0}/datasets/:persistentId/versions/".format(
@@ -1940,8 +1934,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/info/version".format(self.base_url_api_native)
@@ -1961,8 +1955,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/info/server".format(self.base_url_api_native)
@@ -1982,8 +1976,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/info/apiTermsOfUse".format(self.base_url_api_native)
@@ -2002,8 +1996,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/metadatablocks".format(self.base_url_api_native)
@@ -2028,8 +2022,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/metadatablocks/{1}".format(self.base_url_api_native, identifier)
@@ -2046,8 +2040,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/users/token".format(self.base_url_api_native)
@@ -2064,8 +2058,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/users/token/recreate".format(self.base_url_api_native)
@@ -2082,8 +2076,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/users/token".format(self.base_url_api_native)
@@ -2107,8 +2101,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/roles?dvo={1}".format(self.base_url_api_native, dataverse_id)
@@ -2132,8 +2126,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/roles/{1}".format(self.base_url_api_native, role_id)
@@ -2151,8 +2145,8 @@ class NativeApi(Api):
 
         Returns
         -------
-        requests.Response
-            Response object of requests library.
+        httpx.Response
+            Response object of httpx library.
 
         """
         url = "{0}/roles/{1}".format(self.base_url_api_native, role_id)

--- a/pyDataverse/docs/source/conf.py
+++ b/pyDataverse/docs/source/conf.py
@@ -200,5 +200,4 @@ texinfo_documents = [
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "requests": ("https://requests.readthedocs.io/en/master", None),
 }

--- a/pyDataverse/docs/source/index.rst
+++ b/pyDataverse/docs/source/index.rst
@@ -121,7 +121,7 @@ Dataset through the API with
 :meth:`create_dataset() <pyDataverse.api.NativeApi.create_dataset>`.
 
 This returns, as all API functions do, a
-:class:`requests.Response <requests.Response>` object, with the
+:class:`httpx.Response <httpx.Response>` object, with the
 DOI inside ``data``.
 
 Replace following variables with your own instance data

--- a/pyDataverse/docs/source/user/advanced-usage.rst
+++ b/pyDataverse/docs/source/user/advanced-usage.rst
@@ -166,7 +166,7 @@ Note: The Dataverse collection assigned to ``dv_alias`` must be published in ord
     Dataset with pid 'doi:10.5072/FK2/WVMDFE' created.
 
 The API requests always return a
-:class:`requests.Response <requests.Response>` object, which can then be used
+:class:`httpx.Response <httpx.Response>` object, which can then be used
 to extract the data.
 
 Next, we'll do the same for the :class:`list <list>` of

--- a/pyDataverse/docs/source/user/basic-usage.rst
+++ b/pyDataverse/docs/source/user/basic-usage.rst
@@ -63,8 +63,8 @@ if the API connection works and to retrieve the version of your Dataverse instan
     >>> resp.status_code
     200
 
-All API requests return a :class:`requests.Response <requests.Response>` object, which
-can then be used (e. g. :meth:`json() <requests.Response.json>`).
+All API requests return a :class:`httpx.Response <httpx.Response>` object, which
+can then be used (e. g. :meth:`json() <httpx.Response.json>`).
 
 
 .. _user_basic-usage_create-dataverse:


### PR DESCRIPTION
Replace all occurrences of requests.Reponse with httpx.Response.

Also do some minor documentation updates, including some formatting and removal of example texts.
Include :special-members: for the API interface, as the auth-parameter will be documented in the __init__ method, and the docs of the context manager for async were not published yet.
Additionally, remove the intersphinx reference to requests. Unfortunately, httpx does not have an inventory file (see also https://github.com/encode/httpx/discussions/3091)


**Describe your environment**

On host:
* [x] OS: macOS, Sonoma 14.5, M1
* [x] pyDataverse: this PR (i.e., main branch + patches)
* [x] Python: 3.12
* [x] Dataverse: 6.3 (local/container), 6.2 (demo.dataverse.org)

Inside container:
* [x] OS: I think the python images use ubuntu, but didn't check
* [x] pyDataverse: this PR (i.e., main branch + patches)
* [x] Python: 3.11
* [x] Dataverse: 6.3 (!) -- had to override DV_VERSION in docker-compose-test-all.yml to make tests pass, as many check for the version


**Follow best practices**

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/gdcc/pyDataverse/pulls) for the same update/change? #146 is partially affected by this as it changes the params argument of put_request.
* [x] Have you followed the guidelines in our [Contribution Guide](https://pydataverse.readthedocs.io/en/master/contributing/contributing.html)? Yes, but it seems a little outdated. Will create a follow-up issue for this one to update it.
* [x] Have you read the [Code of Conduct](https://github.com/gdcc/pyDataverse/blob/master/CODE_OF_CONDUCT.md)? Yes.
* [x] Do your changes in a separate branch. Branches MUST have descriptive names.
* [x] Have you merged the latest changes from upstream to your branch? Yes

**Describe the PR**

* [x] What kind of change does this PR introduce?
  * Mostly docs <!-- (Bug fix, feature, improvement, docs) -->
* [x] Why is this change required? What problem does it solve?
  * The docs still mention requests, but this is no longer true. Requests and httpx have mostly compatible, but slightly different APIs, so this can cause confusion. (I was confused while debugging datalad/datalad-dataverse#...
* [ ] Screenshots (if appropriate)
* [x] Put `Closes #ISSUE_NUMBER` to the end of this pull request <!-- (e. g. Closes #1234) -->

**Testing**

* [x] Have you used tox and/or pytest for testing the changes? pytest, sh run-tests.sh
* [x] Did the local testing ran successfully? yes (caveat: I applied #197)
* [ ] Did the Continuous Integration testing (Travis-CI) ran successfully?

**Commits**

* [x] Have descriptive commit messages with a short title (first line).
* [x] Use the [commit message template](https://github.com/gdcc/pyDataverse/blob/master/.github/.gitmessage.txt)
* [x] Put `Closes #ISSUE_NUMBER` in your commit messages to auto-close the issue that it fixes (if such).

**Others**

* [ ] Is there anything you need from someone else?

### Documentation contribution

* [x] Have you followed NumPy Docstring standard? I hope so, but there are still a few instances of `:class:\`...\`` which I did not resolve in this PR.

### Code contribution

* [x] Have you used pre-commit?
* [x] Have you formatted your code with black prior to submission (e. g. via pre-commit)?
* [ ] Have you written new tests for your changes? no
* [ ] Have you ran mypy on your changes successfully? haven't run it
* [ ] Have you documented your update (Docstrings and/or Docs)? no
* [ ] Do your changes require additional changes to the documentation? no


Closes #198
