### PR TITLE
Rework auth/api_token parameters

### DIFF
--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -131,15 +131,11 @@ class Api:
                     )
                 )
 
-        if self.base_url:
-            if self.api_version == "latest":
-                self.base_url_api = "{0}/api".format(self.base_url)
-            else:
-                self.base_url_api = "{0}/api/{1}".format(
-                    self.base_url, self.api_version
-                )
+        if self.api_version == "latest":
+            self.base_url_api = "{0}/api".format(self.base_url)
         else:
-            self.base_url_api = None
+            self.base_url_api = "{0}/api/{1}".format(self.base_url, self.api_version)
+
         self.timeout = 500
 
     def __str__(self):

--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -69,12 +69,12 @@ class Api:
         self.base_url = base_url
         self.client = None
 
-        if not isinstance(api_version, ("".__class__, "".__class__)):
+        if not isinstance(api_version, str):
             raise ApiUrlError("api_version {0} is not a string.".format(api_version))
         self.api_version = api_version
 
         if api_token:
-            if not isinstance(api_token, ("".__class__, "".__class__)):
+            if not isinstance(api_token, str):
                 raise ApiAuthorizationError("Api token passed is not a string.")
         self.api_token = api_token
 

--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -260,16 +260,15 @@ class Api:
             return self._sync_request(
                 method=httpx.post,
                 url=url,
-                json=data,
                 headers=headers,
                 params=params,
                 files=files,
+                **request_params,
             )
         else:
             return self._async_request(
                 method=self.client.post,
                 url=url,
-                json=data,
                 headers=headers,
                 params=params,
                 files=files,

--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -18,6 +18,8 @@ from pyDataverse.exceptions import (
     OperationFailedError,
 )
 
+DEPRECATION_GUARD = object()
+
 
 class Api:
     """Base class.
@@ -151,7 +153,7 @@ class Api:
         """
         return f"{self.__class__.__name__}: {self.base_url_api}"
 
-    def get_request(self, url, params=None, auth=False):
+    def get_request(self, url, params=None, auth=DEPRECATION_GUARD):
         """Make a GET request.
 
         Parameters
@@ -161,8 +163,18 @@ class Api:
         params : dict
             Dictionary of parameters to be passed with the request.
             Defaults to `None`.
-        auth : bool
-            Should an api token be sent in the request. Defaults to `False`.
+        auth : Any
+            .. deprecated:: 0.3.4
+                The auth parameter was ignored before version 0.3.4.
+                Please pass your auth to the Api instance directly, as
+                explained in :py:func:`Api.__init__`.
+                If you need multiple auth methods, create multiple
+                API instances:
+
+                .. code-block:: python
+
+                    api = Api("https://demo.dataverse.org", auth=ApiTokenAuth("my_api_token"))
+                    api_oauth = Api("https://demo.dataverse.org", auth=BearerTokenAuth("my_bearer_token"))
 
         Returns
         -------
@@ -170,6 +182,13 @@ class Api:
             Response object of httpx library.
 
         """
+        if auth is not DEPRECATION_GUARD:
+            warn(
+                DeprecationWarning(
+                    "The auth parameter is deprecated. Please pass your auth "
+                    "arguments to the __init__ method instead."
+                )
+            )
         headers = {}
         headers["User-Agent"] = "pydataverse"
 
@@ -188,7 +207,9 @@ class Api:
                 params=params,
             )
 
-    def post_request(self, url, data=None, auth=False, params=None, files=None):
+    def post_request(
+        self, url, data=None, auth=DEPRECATION_GUARD, params=None, files=None
+    ):
         """Make a POST request.
 
         params will be added as key-value pairs to the URL.
@@ -199,8 +220,18 @@ class Api:
             Full URL.
         data : str
             Metadata as a json-formatted string. Defaults to `None`.
-        auth : bool
-            Should an api token be sent in the request. Defaults to `False`.
+        auth : Any
+            .. deprecated:: 0.3.4
+                The auth parameter was ignored before version 0.3.4.
+                Please pass your auth to the Api instance directly, as
+                explained in :py:func:`Api.__init__`.
+                If you need multiple auth methods, create multiple
+                API instances:
+
+                .. code-block:: python
+
+                    api = Api("https://demo.dataverse.org", auth=ApiTokenAuth("my_api_token"))
+                    api_oauth = Api("https://demo.dataverse.org", auth=BearerTokenAuth("my_bearer_token"))
         files : dict
             e.g. :code:`files={'file': open('sample_file.txt','rb')}`
         params : dict
@@ -213,6 +244,13 @@ class Api:
             Response object of httpx library.
 
         """
+        if auth is not DEPRECATION_GUARD:
+            warn(
+                DeprecationWarning(
+                    "The auth parameter is deprecated. Please pass your auth "
+                    "arguments to the __init__ method instead."
+                )
+            )
         headers = {}
         headers["User-Agent"] = "pydataverse"
 
@@ -242,7 +280,7 @@ class Api:
                 **request_params,
             )
 
-    def put_request(self, url, data=None, auth=False, params=None):
+    def put_request(self, url, data=None, auth=DEPRECATION_GUARD, params=None):
         """Make a PUT request.
 
         Parameters
@@ -251,8 +289,18 @@ class Api:
             Full URL.
         data : str
             Metadata as a json-formatted string. Defaults to `None`.
-        auth : bool
-            Should an api token be sent in the request. Defaults to `False`.
+        auth : Any
+            .. deprecated:: 0.3.4
+                The auth parameter was ignored before version 0.3.4.
+                Please pass your auth to the Api instance directly, as
+                explained in :py:func:`Api.__init__`.
+                If you need multiple auth methods, create multiple
+                API instances:
+
+                .. code-block:: python
+
+                    api = Api("https://demo.dataverse.org", auth=ApiTokenAuth("my_api_token"))
+                    api_oauth = Api("https://demo.dataverse.org", auth=BearerTokenAuth("my_bearer_token"))
         params : dict
             Dictionary of parameters to be passed with the request.
             Defaults to `None`.
@@ -263,6 +311,13 @@ class Api:
             Response object of httpx library.
 
         """
+        if auth is not DEPRECATION_GUARD:
+            warn(
+                DeprecationWarning(
+                    "The auth parameter is deprecated. Please pass your auth "
+                    "arguments to the __init__ method instead."
+                )
+            )
         headers = {}
         headers["User-Agent"] = "pydataverse"
 
@@ -291,15 +346,25 @@ class Api:
                 **request_params,
             )
 
-    def delete_request(self, url, auth=False, params=None):
+    def delete_request(self, url, auth=DEPRECATION_GUARD, params=None):
         """Make a Delete request.
 
         Parameters
         ----------
         url : str
             Full URL.
-        auth : bool
-            Should an api token be sent in the request. Defaults to `False`.
+        auth : Any
+            .. deprecated:: 0.3.4
+                The auth parameter was ignored before version 0.3.4.
+                Please pass your auth to the Api instance directly, as
+                explained in :py:func:`Api.__init__`.
+                If you need multiple auth methods, create multiple
+                API instances:
+
+                .. code-block:: python
+
+                    api = Api("https://demo.dataverse.org", auth=ApiTokenAuth("my_api_token"))
+                    api_oauth = Api("https://demo.dataverse.org", auth=BearerTokenAuth("my_bearer_token"))
         params : dict
             Dictionary of parameters to be passed with the request.
             Defaults to `None`.
@@ -310,6 +375,13 @@ class Api:
             Response object of httpx library.
 
         """
+        if auth is not DEPRECATION_GUARD:
+            warn(
+                DeprecationWarning(
+                    "The auth parameter is deprecated. Please pass your auth "
+                    "arguments to the __init__ method instead."
+                )
+            )
         headers = {}
         headers["User-Agent"] = "pydataverse"
 
@@ -504,7 +576,7 @@ class DataAccessApi(Api):
         no_var_header=None,
         image_thumb=None,
         is_pid=True,
-        auth=False,
+        auth=DEPRECATION_GUARD,
     ):
         """Download a datafile via the Dataverse Data Access API.
 
@@ -557,7 +629,7 @@ class DataAccessApi(Api):
             url += "imageThumb={0}".format(image_thumb)
         return self.get_request(url, auth=auth)
 
-    def get_datafiles(self, identifier, data_format=None, auth=False):
+    def get_datafiles(self, identifier, data_format=None, auth=DEPRECATION_GUARD):
         """Download a datafile via the Dataverse Data Access API.
 
         Get by file id (HTTP Request).
@@ -585,7 +657,9 @@ class DataAccessApi(Api):
             url += "?format={0}".format(data_format)
         return self.get_request(url, auth=auth)
 
-    def get_datafile_bundle(self, identifier, file_metadata_id=None, auth=False):
+    def get_datafile_bundle(
+        self, identifier, file_metadata_id=None, auth=DEPRECATION_GUARD
+    ):
         """Download a datafile in all its formats.
 
         HTTP Request:
@@ -628,7 +702,7 @@ class DataAccessApi(Api):
             url += "?fileMetadataId={0}".format(file_metadata_id)
         return self.get_request(url, auth=auth)
 
-    def request_access(self, identifier, auth=True, is_filepid=False):
+    def request_access(self, identifier, auth=DEPRECATION_GUARD, is_filepid=False):
         """Request datafile access.
 
         This method requests access to the datafile whose id is passed on the behalf of an authenticated user whose key is passed. Note that not all datasets allow access requests to restricted files.
@@ -649,7 +723,9 @@ class DataAccessApi(Api):
             )
         return self.put_request(url, auth=auth)
 
-    def allow_access_request(self, identifier, do_allow=True, auth=True, is_pid=True):
+    def allow_access_request(
+        self, identifier, do_allow=True, auth=DEPRECATION_GUARD, is_pid=True
+    ):
         """Allow access request for datafiles.
 
         https://guides.dataverse.org/en/latest/api/dataaccess.html#allow-access-requests
@@ -672,7 +748,7 @@ class DataAccessApi(Api):
             data = "false"
         return self.put_request(url, data=data, auth=auth)
 
-    def grant_file_access(self, identifier, user, auth=False):
+    def grant_file_access(self, identifier, user, auth=DEPRECATION_GUARD):
         """Grant datafile access.
 
         https://guides.dataverse.org/en/4.18.1/api/dataaccess.html#grant-file-access
@@ -684,7 +760,7 @@ class DataAccessApi(Api):
         )
         return self.put_request(url, auth=auth)
 
-    def list_file_access_requests(self, identifier, auth=False):
+    def list_file_access_requests(self, identifier, auth=DEPRECATION_GUARD):
         """Liste datafile access requests.
 
         https://guides.dataverse.org/en/4.18.1/api/dataaccess.html#list-file-access-requests
@@ -717,7 +793,7 @@ class MetricsApi(Api):
         else:
             self.base_url_api_metrics = None
 
-    def total(self, data_type, date_str=None, auth=False):
+    def total(self, data_type, date_str=None, auth=DEPRECATION_GUARD):
         """
         GET https://$SERVER/api/info/metrics/$type
         GET https://$SERVER/api/info/metrics/$type/toMonth/$YYYY-DD
@@ -730,7 +806,7 @@ class MetricsApi(Api):
             url += "/toMonth/{0}".format(date_str)
         return self.get_request(url, auth=auth)
 
-    def past_days(self, data_type, days_str, auth=False):
+    def past_days(self, data_type, days_str, auth=DEPRECATION_GUARD):
         """
 
         http://guides.dataverse.org/en/4.18.1/api/metrics.html
@@ -744,7 +820,7 @@ class MetricsApi(Api):
         )
         return self.get_request(url, auth=auth)
 
-    def get_dataverses_by_subject(self, auth=False):
+    def get_dataverses_by_subject(self, auth=DEPRECATION_GUARD):
         """
         GET https://$SERVER/api/info/metrics/dataverses/bySubject
 
@@ -754,7 +830,7 @@ class MetricsApi(Api):
         url = "{0}/dataverses/bySubject".format(self.base_url_api_metrics)
         return self.get_request(url, auth=auth)
 
-    def get_dataverses_by_category(self, auth=False):
+    def get_dataverses_by_category(self, auth=DEPRECATION_GUARD):
         """
         GET https://$SERVER/api/info/metrics/dataverses/byCategory
 
@@ -764,7 +840,7 @@ class MetricsApi(Api):
         url = "{0}/dataverses/byCategory".format(self.base_url_api_metrics)
         return self.get_request(url, auth=auth)
 
-    def get_datasets_by_subject(self, date_str=None, auth=False):
+    def get_datasets_by_subject(self, date_str=None, auth=DEPRECATION_GUARD):
         """
         GET https://$SERVER/api/info/metrics/datasets/bySubject
 
@@ -776,7 +852,7 @@ class MetricsApi(Api):
             url += "/toMonth/{0}".format(date_str)
         return self.get_request(url, auth=auth)
 
-    def get_datasets_by_data_location(self, data_location, auth=False):
+    def get_datasets_by_data_location(self, data_location, auth=DEPRECATION_GUARD):
         """
         GET https://$SERVER/api/info/metrics/datasets/bySubject
 
@@ -825,7 +901,7 @@ class NativeApi(Api):
         super().__init__(base_url, api_token, api_version, auth=auth)
         self.base_url_api_native = self.base_url_api
 
-    def get_dataverse(self, identifier, auth=False):
+    def get_dataverse(self, identifier, auth=DEPRECATION_GUARD):
         """Get dataverse metadata by alias or id.
 
         View metadata about a dataverse.
@@ -1066,7 +1142,7 @@ class NativeApi(Api):
         url = "{0}/dataverses/{1}/contents".format(self.base_url_api_native, identifier)
         return self.get_request(url, auth=auth)
 
-    def get_dataverse_assignments(self, identifier, auth=False):
+    def get_dataverse_assignments(self, identifier, auth=DEPRECATION_GUARD):
         """Get dataverse assignments by alias or id.
 
         View assignments of a dataverse.
@@ -1092,7 +1168,7 @@ class NativeApi(Api):
         )
         return self.get_request(url, auth=auth)
 
-    def get_dataverse_facets(self, identifier, auth=False):
+    def get_dataverse_facets(self, identifier, auth=DEPRECATION_GUARD):
         """Get dataverse facets by alias or id.
 
         View facets of a dataverse.
@@ -1116,7 +1192,7 @@ class NativeApi(Api):
         url = "{0}/dataverses/{1}/facets".format(self.base_url_api_native, identifier)
         return self.get_request(url, auth=auth)
 
-    def dataverse_id2alias(self, dataverse_id, auth=False):
+    def dataverse_id2alias(self, dataverse_id, auth=DEPRECATION_GUARD):
         """Converts a Dataverse ID to an alias.
 
         Parameters
@@ -1265,7 +1341,7 @@ class NativeApi(Api):
             )
         return self.get_request(url, auth=auth)
 
-    def get_dataset_export(self, pid, export_format, auth=False):
+    def get_dataset_export(self, pid, export_format, auth=DEPRECATION_GUARD):
         """Get metadata of dataset exported in different formats.
 
         Export the metadata of the current published version of a dataset
@@ -1975,7 +2051,7 @@ class NativeApi(Api):
             url += "/files/{0}/replace".format(identifier)
         return self.post_request(url, data=data, files=files, auth=True)
 
-    def get_info_version(self, auth=False):
+    def get_info_version(self, auth=DEPRECATION_GUARD):
         """Get the Dataverse version and build number.
 
         The response contains the version and build numbers. Requires no api
@@ -1996,7 +2072,7 @@ class NativeApi(Api):
         url = "{0}/info/version".format(self.base_url_api_native)
         return self.get_request(url, auth=auth)
 
-    def get_info_server(self, auth=False):
+    def get_info_server(self, auth=DEPRECATION_GUARD):
         """Get dataverse server name.
 
         This is useful when a Dataverse system is composed of multiple Java EE
@@ -2017,7 +2093,7 @@ class NativeApi(Api):
         url = "{0}/info/server".format(self.base_url_api_native)
         return self.get_request(url, auth=auth)
 
-    def get_info_api_terms_of_use(self, auth=False):
+    def get_info_api_terms_of_use(self, auth=DEPRECATION_GUARD):
         """Get API Terms of Use url.
 
         The response contains the text value inserted as API Terms of use which
@@ -2038,7 +2114,7 @@ class NativeApi(Api):
         url = "{0}/info/apiTermsOfUse".format(self.base_url_api_native)
         return self.get_request(url, auth=auth)
 
-    def get_metadatablocks(self, auth=False):
+    def get_metadatablocks(self, auth=DEPRECATION_GUARD):
         """Get info about all metadata blocks.
 
         Lists brief info about all metadata blocks registered in the system.
@@ -2058,7 +2134,7 @@ class NativeApi(Api):
         url = "{0}/metadatablocks".format(self.base_url_api_native)
         return self.get_request(url, auth=auth)
 
-    def get_metadatablock(self, identifier, auth=False):
+    def get_metadatablock(self, identifier, auth=DEPRECATION_GUARD):
         """Get info about single metadata block.
 
         Returns data about the block whose identifier is passed. identifier can
@@ -2084,7 +2160,7 @@ class NativeApi(Api):
         url = "{0}/metadatablocks/{1}".format(self.base_url_api_native, identifier)
         return self.get_request(url, auth=auth)
 
-    def get_user_api_token_expiration_date(self, auth=False):
+    def get_user_api_token_expiration_date(self, auth=DEPRECATION_GUARD):
         """Get the expiration date of an Users's API token.
 
         HTTP Request:
@@ -2163,7 +2239,7 @@ class NativeApi(Api):
         url = "{0}/roles?dvo={1}".format(self.base_url_api_native, dataverse_id)
         return self.post_request(url)
 
-    def show_role(self, role_id, auth=False):
+    def show_role(self, role_id, auth=DEPRECATION_GUARD):
         """Show role.
 
         `Docs <https://guides.dataverse.org/en/latest/api/native-api.html#show-role>`_
@@ -2506,7 +2582,7 @@ class SearchApi(Api):
         filter_query=None,
         show_entity_ids=None,
         query_entities=None,
-        auth=False,
+        auth=DEPRECATION_GUARD,
     ):
         """Search.
 

--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -90,7 +90,7 @@ class Api:
         self.timeout = 500
 
     def __str__(self):
-        """Return name of Api() class for users.
+        """Return the class name and URL of the used API class.
 
         Returns
         -------
@@ -98,7 +98,7 @@ class Api:
             Naming of the API class.
 
         """
-        return "API: {0}".format(self.base_url_api)
+        return f"{self.__class__.__name__}: {self.base_url_api}"
 
     def get_request(self, url, params=None, auth=False):
         """Make a GET request.
@@ -439,17 +439,6 @@ class DataAccessApi(Api):
         else:
             self.base_url_api_data_access = self.base_url_api
 
-    def __str__(self):
-        """Return name of DataAccessApi() class for users.
-
-        Returns
-        -------
-        str
-            Naming of the DataAccess API class.
-
-        """
-        return "Data Access API: {0}".format(self.base_url_api_data_access)
-
     def get_datafile(
         self,
         identifier,
@@ -670,17 +659,6 @@ class MetricsApi(Api):
         else:
             self.base_url_api_metrics = None
 
-    def __str__(self):
-        """Return name of MetricsApi() class for users.
-
-        Returns
-        -------
-        str
-            Naming of the MetricsApi() class.
-
-        """
-        return "Metrics API: {0}".format(self.base_url_api_metrics)
-
     def total(self, data_type, date_str=None, auth=False):
         """
         GET https://$SERVER/api/info/metrics/$type
@@ -788,17 +766,6 @@ class NativeApi(Api):
         """
         super().__init__(base_url, api_token, api_version)
         self.base_url_api_native = self.base_url_api
-
-    def __str__(self):
-        """Return name of NativeApi() class for users.
-
-        Returns
-        -------
-        str
-            Naming of the NativeApi() class.
-
-        """
-        return "Native API: {0}".format(self.base_url_api_native)
 
     def get_dataverse(self, identifier, auth=False):
         """Get dataverse metadata by alias or id.
@@ -2467,17 +2434,6 @@ class SearchApi(Api):
         else:
             self.base_url_api_search = self.base_url_api
 
-    def __str__(self):
-        """Return name of SearchApi() class for users.
-
-        Returns
-        -------
-        str
-            Naming of the Search API class.
-
-        """
-        return "Search API: {0}".format(self.base_url_api_search)
-
     def search(
         self,
         q_str,
@@ -2571,17 +2527,6 @@ class SwordApi(Api):
             )
         else:
             self.base_url_api_sword = base_url
-
-    def __str__(self):
-        """Return name of :class:Api() class for users.
-
-        Returns
-        -------
-        str
-            Naming of the SWORD API class.
-
-        """
-        return "SWORD API: {0}".format(self.base_url_api_sword)
 
     def get_service_document(self):
         url = "{0}/swordv2/service-document".format(self.base_url_api_sword)

--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -2647,8 +2647,26 @@ class SwordApi(Api):
         ----------
         sword_api_version : str
             Api version of Dataverse SWORD API.
+        api_token : str | None
+            An Api token as retrieved from your Dataverse instance.
+        auth : httpx.Auth
+            Note that the SWORD API uses a different authentication mechanism
+            than the native API, in particular it uses `HTTP Basic
+            Authentication
+            <https://guides.dataverse.org/en/latest/api/sword.html#sword-auth>`_.
+            Thus, if you pass an api_token, it will be used as the username in
+            the HTTP Basic Authentication. If you pass a custom :py:class:`httpx.Auth`, use
+            :py:class:`httpx.BasicAuth` with an empty password:
+
+            .. code-block:: python
+
+                sword_api = Api(
+                    "https://demo.dataverse.org", auth=httpx.BasicAuth(username="my_token", password="")
+                )
 
         """
+        if auth is None and api_token is not None:
+            auth = httpx.BasicAuth(api_token, "")
         super().__init__(base_url, api_token, api_version, auth=auth)
         if not isinstance(sword_api_version, ("".__class__, "".__class__)):
             raise ApiUrlError(

--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -447,9 +447,14 @@ class Api:
         kwargs = self._filter_kwargs(kwargs)
 
         try:
-            resp = method(**kwargs, auth=self.auth, follow_redirects=True, timeout=None)
+            resp: httpx.Response = method(
+                **kwargs, auth=self.auth, follow_redirects=True, timeout=None
+            )
             if resp.status_code == 401:
-                error_msg = resp.json()["message"]
+                try:
+                    error_msg = resp.json()["message"]
+                except json.JSONDecodeError:
+                    error_msg = resp.reason_phrase
                 raise ApiAuthorizationError(
                     "ERROR: HTTP 401 - Authorization error {0}. MSG: {1}".format(
                         kwargs["url"], error_msg

--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -90,8 +90,8 @@ class Api:
             `httpx' Authentication docs
             <https://www.python-httpx.org/advanced/authentication/>`_.
         Examples
-        --------
-        Create an Api connection::
+        -------
+        Create an API connection::
 
         .. code-block::
 
@@ -891,7 +891,7 @@ class NativeApi(Api):
         Parameters
         ----------
         native_api_version : str
-            Api version of Dataverse native api. Default is `v1`.
+            API version of Dataverse native API. Default is `v1`.
 
         """
         super().__init__(base_url, api_token, api_version, auth=auth)

--- a/pyDataverse/auth.py
+++ b/pyDataverse/auth.py
@@ -21,7 +21,7 @@ class ApiTokenAuth(Auth):
         Parameters
         ----------
         api_token : str
-            The API token retrieved from your dataverse instance user profile.
+            The API token retrieved from your Dataverse instance user profile.
 
         Examples
         --------
@@ -34,7 +34,7 @@ class ApiTokenAuth(Auth):
 
         """
         if not isinstance(api_token, str):
-            raise ApiAuthorizationError("Api token passed is not a string.")
+            raise ApiAuthorizationError("API token passed is not a string.")
         self.api_token = api_token
 
     def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
@@ -82,7 +82,7 @@ class BearerTokenAuth(Auth):
 
         """
         if not isinstance(bearer_token, str):
-            raise ApiAuthorizationError("Api token passed is not a string.")
+            raise ApiAuthorizationError("API token passed is not a string.")
         self.bearer_token = bearer_token
 
     def auth_flow(self, request: Request) -> Generator[Request, Response, None]:

--- a/pyDataverse/auth.py
+++ b/pyDataverse/auth.py
@@ -1,0 +1,103 @@
+"""This module contains authentication handlers compatible with :class:`httpx.Auth`"""
+
+from typing import Generator
+
+from httpx import Auth, Request, Response
+
+from pyDataverse.exceptions import ApiAuthorizationError
+
+
+class ApiTokenAuth(Auth):
+    """An authentication handler to add an API token as the X-Dataverse-key
+    header.
+
+    For more information on how to retrieve an API token and how it is used,
+    please refer to https://guides.dataverse.org/en/latest/api/auth.html.
+    """
+
+    def __init__(self, api_token: str):
+        """Initializes the auth handler with an API token.
+
+        Parameters
+        ----------
+        api_token : str
+            The API token retrieved from your dataverse instance user profile.
+
+        Examples
+        --------
+
+            >>> import os
+            >>> from pyDataverse.api import DataAccessApi
+            >>> base_url = 'https://demo.dataverse.org'
+            >>> api_token_auth = ApiTokenAuth(os.getenv('API_TOKEN'))
+            >>> api = DataAccessApi(base_url, api_token_auth)
+
+        """
+        if not isinstance(api_token, str):
+            raise ApiAuthorizationError("Api token passed is not a string.")
+        self.api_token = api_token
+
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        """Adds the X-Dataverse-key header with the API token and yields the
+        original :class:`httpx.Request`.
+
+        Parameters
+        ----------
+        request : httpx.Request
+            The request object which requires authentication headers
+
+        Yields
+        ------
+        httpx.Request
+            The original request with modified headers
+        """
+        request.headers["X-Dataverse-key"] = self.api_token
+        yield request
+
+
+class BearerTokenAuth(Auth):
+    """An authentication handler to add a Bearer token as defined in `RFC 6750
+    <https://datatracker.ietf.org/doc/html/rfc6750>`_ to the request.
+
+    A bearer token could be obtained from an OIDC provider, for example,
+    Keycloak.
+    """
+
+    def __init__(self, bearer_token: str):
+        """Initializes the auth handler with a bearer token.
+
+        Parameters
+        ----------
+        bearer_token : str
+            The bearer token retrieved from your OIDC provider.
+
+        Examples
+        --------
+
+            >>> import os
+            >>> from pyDataverse.api import DataAccessApi
+            >>> base_url = 'https://demo.dataverse.org'
+            >>> bearer_token_auth = OAuthBearerTokenAuth(os.getenv('OAUTH_TOKEN'))
+            >>> api = DataAccessApi(base_url, bearer_token_auth)
+
+        """
+        if not isinstance(bearer_token, str):
+            raise ApiAuthorizationError("Api token passed is not a string.")
+        self.bearer_token = bearer_token
+
+    def auth_flow(self, request: Request) -> Generator[Request, Response, None]:
+        """Adds the X-Dataverse-key header with the API token and yields the
+        original :class:`httpx.Request`.
+
+        Parameters
+        ----------
+        request : httpx.Request
+            The request object which requires authentication headers
+
+        Yields
+        ------
+        httpx.Request
+            The original request with modified headers
+        """
+        request.headers["Authorization"] = f"Bearer {self.bearer_token}"
+        yield request

--- a/pyDataverse/docs/source/reference.rst
+++ b/pyDataverse/docs/source/reference.rst
@@ -38,6 +38,13 @@ Helper functions.
   :members:
 
 
+Auth Helpers
+-----------------------------
+
+.. automodule:: pyDataverse.auth
+  :members:
+
+
 Exceptions
 -----------------------------
 

--- a/pyDataverse/docs/source/reference.rst
+++ b/pyDataverse/docs/source/reference.rst
@@ -17,6 +17,7 @@ Access all of Dataverse APIs.
 
 .. automodule:: pyDataverse.api
    :members:
+   :special-members:
 
 
 Models Interface

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ optional = true
 [tool.poetry.group.tests.dependencies]
 pytest = "^8.1.1"
 pytest-cov = "^5.0.0"
+pytest-asyncio = "^0.23.7"
 tox = "^4.14.2"
 selenium = "^4.19.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ optional = true
 black = "^24.3.0"
 radon = "^6.0.1"
 mypy = "^1.9.0"
+types-jsonschema = "^4.23.0"
 autopep8 = "^2.1.0"
 ruff = "^0.4.4"
 

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -189,3 +189,24 @@ if not os.environ.get("TRAVIS"):
 
             result = api.get_datafile("does-not-exist").json()
             assert API_TOKEN not in result["requestUrl"]
+
+        @pytest.mark.parametrize(
+            "auth", (True, False, "api-token", ApiTokenAuth("some-token"))
+        )
+        def test_using_auth_on_individual_requests_is_deprecated(self, auth):
+            BASE_URL = os.getenv("BASE_URL")
+            API_TOKEN = os.getenv("API_TOKEN")
+            api = DataAccessApi(BASE_URL, auth=ApiTokenAuth(API_TOKEN))
+            with pytest.warns(DeprecationWarning):
+                api.get_datafile("does-not-exist", auth=auth)
+
+        @pytest.mark.parametrize(
+            "auth", (True, False, "api-token", ApiTokenAuth("some-token"))
+        )
+        def test_using_auth_on_individual_requests_is_deprecated_unauthorized(
+            self, auth
+        ):
+            BASE_URL = os.getenv("BASE_URL")
+            no_auth_api = DataAccessApi(BASE_URL)
+            with pytest.warns(DeprecationWarning):
+                no_auth_api.get_datafile("does-not-exist", auth=auth)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,8 +1,9 @@
 import os
+import httpx
 import pytest
 from httpx import Response
 from time import sleep
-from pyDataverse.api import DataAccessApi, NativeApi
+from pyDataverse.api import DataAccessApi, NativeApi, SwordApi
 from pyDataverse.auth import ApiTokenAuth
 from pyDataverse.exceptions import ApiAuthorizationError
 from pyDataverse.exceptions import ApiUrlError
@@ -210,3 +211,9 @@ if not os.environ.get("TRAVIS"):
             no_auth_api = DataAccessApi(BASE_URL)
             with pytest.warns(DeprecationWarning):
                 no_auth_api.get_datafile("does-not-exist", auth=auth)
+
+        def test_sword_api_requires_http_basic_auth(self):
+            BASE_URL = os.getenv("BASE_URL")
+            API_TOKEN = os.getenv("API_TOKEN")
+            api = SwordApi(BASE_URL, api_token=API_TOKEN)
+            assert isinstance(api.auth, httpx.BasicAuth)

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -2,7 +2,7 @@ import os
 import pytest
 from httpx import Response
 from time import sleep
-from pyDataverse.api import NativeApi
+from pyDataverse.api import DataAccessApi, NativeApi
 from pyDataverse.exceptions import ApiAuthorizationError
 from pyDataverse.exceptions import ApiUrlError
 from pyDataverse.models import Dataset
@@ -150,3 +150,11 @@ if not os.environ.get("TRAVIS"):
 
             resp = api_su.delete_dataset(pid)
             assert resp.json()["status"] == "OK"
+
+        def test_token_should_not_be_exposed_on_error(self):
+            BASE_URL = os.getenv("BASE_URL")
+            API_TOKEN = os.getenv("API_TOKEN")
+            api = DataAccessApi(BASE_URL, API_TOKEN)
+
+            result = api.get_datafile("does-not-exist").json()
+            assert API_TOKEN not in result["requestUrl"]

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -217,3 +217,16 @@ if not os.environ.get("TRAVIS"):
             API_TOKEN = os.getenv("API_TOKEN")
             api = SwordApi(BASE_URL, api_token=API_TOKEN)
             assert isinstance(api.auth, httpx.BasicAuth)
+
+        def test_sword_api_can_authenticate(self):
+            BASE_URL = os.getenv("BASE_URL")
+            API_TOKEN = os.getenv("API_TOKEN")
+            api = SwordApi(BASE_URL, api_token=API_TOKEN)
+            response = api.get_service_document()
+            assert response.status_code == 200
+
+        def test_sword_api_cannot_authenticate_without_token(self):
+            BASE_URL = os.getenv("BASE_URL")
+            api = SwordApi(BASE_URL)
+            with pytest.raises(ApiAuthorizationError):
+                api.get_service_document()

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -1,0 +1,44 @@
+import uuid
+
+import pytest
+from httpx import Request
+
+from pyDataverse.auth import ApiTokenAuth, BearerTokenAuth
+from pyDataverse.exceptions import ApiAuthorizationError
+
+
+class TestApiTokenAuth:
+    def test_token_header_is_added_during_auth_flow(self):
+        api_token = str(uuid.uuid4())
+        auth = ApiTokenAuth(api_token)
+        request = Request("GET", "https://example.org")
+        assert "X-Dataverse-key" not in request.headers
+        modified_request = next(auth.auth_flow(request))
+        assert "X-Dataverse-key" in modified_request.headers
+        assert modified_request.headers["X-Dataverse-key"] == api_token
+
+    @pytest.mark.parametrize(
+        "non_str_token", (123, object(), lambda x: x, 1.423, b"123", uuid.uuid4())
+    )
+    def test_raise_if_token_is_not_str(self, non_str_token):
+        with pytest.raises(ApiAuthorizationError):
+            ApiTokenAuth(non_str_token)
+
+
+class TestBearerTokenAuth:
+    def test_authorization_header_is_added_during_auth_flow(self):
+        # Token as shown in RFC 6750
+        bearer_token = "mF_9.B5f-4.1JqM"
+        auth = BearerTokenAuth(bearer_token)
+        request = Request("GET", "https://example.org")
+        assert "Authorization" not in request.headers
+        modified_request = next(auth.auth_flow(request))
+        assert "Authorization" in modified_request.headers
+        assert modified_request.headers["Authorization"] == f"Bearer {bearer_token}"
+
+    @pytest.mark.parametrize(
+        "non_str_token", (123, object(), lambda x: x, 1.423, b"123", uuid.uuid4())
+    )
+    def test_raise_if_token_is_not_str(self, non_str_token):
+        with pytest.raises(ApiAuthorizationError):
+            BearerTokenAuth(non_str_token)


### PR DESCRIPTION
**Describe your environment**

On host:
* [x] OS: macOS, Sonoma 14.5, M1
* [x] pyDataverse: this PR (i.e., main branch + patches)
* [x] Python: 3.12
* [x] Dataverse: 6.3 (local/container), 6.2 (demo.dataverse.org)

Inside container:
* [x] OS: I think the python images use ubuntu, but didn't check
* [x] pyDataverse: this PR (i.e., main branch + patches)
* [x] Python: 3.11
* [x] Dataverse: 6.3 (!) -- had to override DV_VERSION in docker-compose-test-all.yml to make tests pass, as three tests check for the version. See also #197 .


**Follow best practices**

* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/gdcc/pyDataverse/pulls) for the same update/change? #146 is partially affected by this as it changes the params argument of `put_request`.
* [x] Have you followed the guidelines in our [Contribution Guide](https://pydataverse.readthedocs.io/en/master/contributing/contributing.html)? Yes, see #193 .
* [x] Have you read the [Code of Conduct](https://github.com/gdcc/pyDataverse/blob/master/CODE_OF_CONDUCT.md)? Yes.
* [x] Do your changes in a separate branch. Branches MUST have descriptive names.
* [x] Have you merged the latest changes from upstream to your branch? Yes

**Describe the PR**

* [x] What kind of change does this PR introduce?
  * This PR introduces custom authentication implementation to allow for API token and Bearer token-based authentication.
  * Sword requires BasicAuth, which this PR also addresses (see https://guides.dataverse.org/en/latest/api/sword.html#sword-auth)
  * An Auth implementation must be passed as a keyword-argument to the __init__ function. We can discuss this requirement, but it felt better to be explicit about it and make sure implementers actually pass it correctly rather than accidentally passing it as the api_token or something.
  * I replaced some `isinstance(..., ("".__class__, "".__class__))` with the much more legible and equivalent (as far as I can tell) `isinstance(..., str)`.
  * It also deprecates the use of the previously ignored `auth` on individual functions in favor of generating multiple API objects with different auth methods.
    * For the deprecation, I introduced a DEPRECATION_GUARD to warn people who are trying to pass something to the functions. Initially I wanted to check for `False`, but there was one call defaulting to `True` (`get_access`) and this would not catch code explicitly setting `auth=False` on the callsite. So I decided to introduce a new default argument and show a warning if it is overwritten. Happy to discuss this decision – I have never done such an orderly deprecation before, so this is my first try :)
  * I updated the documentation.
  * Oh, and I smuggled a change to the `Api.__str__` methods into the PR. As I scrolled by, I saw that they essentially could be removed and just the `Api.__str__` method itself should use `self.__class__.__name__` to get a similar result. However, the DataAccessApi will not print `DataAccessApi: ...` instead of the previous `Data Access API: ...` – the same applies for the others. However, this felt to be more in spirit with the docstring (which I then also updated slightly). If that's not so nice, we can move that to its own PR or even drop that commit entirely.
  * I had to adapt three unrelated things (conf.py, the `self.base_url = None` assignment in api.py, and the pyproject.toml) for mypy.
  * This PR almost accidentally also allows to pass `params` properly due to the name change of params -> headers.
* [x] Why is this change required? What problem does it solve?
  * First and foremost, the issue it resolves is that tokens could potentially be leaked when sharing log messages, as the error response from dataverse includes the request URL, which, if the token is provided as ?key, contains the key.
  * The PR also lays the groundwork to allow for different authentication schemas in the future and even to configure it from the outside, favoring composition over inheritance. This will hopefully make maintenance and the refactoring in #189 easier.
  * By deprecating the auth on individual methods, it will eventually be possible to remove this unused argument and make the API a little bit leaner and reduce confusing behavior.
* [ ] Screenshots (if appropriate)
* [x] Put `Closes #ISSUE_NUMBER` to the end of this pull request

**Testing**

* [x] Have you used tox and/or pytest for testing the changes? pytest
* [x] Did the local testing ran successfully? yes, if applying #197. For demo.dataverse.org, I could not run test_upload.py successfully, as I was unauthorized to perform those uploads (401). However, locally (outside the containers) I was able to run the asyncio tests with pytest-asyncio. The containers seem to miss this.
* [ ] Did the Continuous Integration testing (Travis-CI) ran successfully?

**Commits**

* [x] Have descriptive commit messages with a short title (first line).
* [x] Use the [commit message template](https://github.com/gdcc/pyDataverse/blob/master/.github/.gitmessage.txt)
* [x] Put `Closes #ISSUE_NUMBER` in your commit messages to auto-close the issue that it fixes (if such).
  * I have only done this for 3e73fbf, as that is arguably the "essence" of this PR.

**Others**

* [x] Is there anything you need from someone else? Take your time to review these changes. While some are quite repetitive and I already split some parts off into other PRs, this is a massive changeset due to the deprecation. In fact, maybe the deprecation should be its own PR? What do you think?

### Documentation contribution

* [?] Have you followed NumPy Docstring standard? I hope so

### Code contribution

* [x] Have you used pre-commit? Yes, see also #196.
* [x] Have you formatted your code with black prior to submission (e. g. via pre-commit)? Yes
* [x] Have you written new tests for your changes? Yes
* [x] Have you ran mypy on your changes successfully? Yes, but I had to add types-jsonschema to the lint dependencies and in the conf.py. I haven't tried --strict.
* [x] Have you documented your update (Docstrings and/or Docs)? yes
* [x] Do your changes require additional changes to the documentation? No, but m

Note that this PR depends on other PRs which should be reviewed and decided/acted upon first, I can also rebase/merge the changes into this branch afterwards.
In particular:
- #196
- #197

Closes #192 .
