### PR TITLE
Fix `jsonData` not passed correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ poetry.lock
 
 # Ruff
 .ruff_cache/
+
+# JetBrains
+.idea/

--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -167,7 +167,6 @@ class Api:
         if self.api_token:
             params["key"] = self.api_token
 
-
         if isinstance(data, str):
             data = json.loads(data)
 
@@ -176,11 +175,7 @@ class Api:
 
         if self.client is None:
             return self._sync_request(
-                method=httpx.post,
-                url=url,
-                params=params,
-                files=files,
-                **request_params
+                method=httpx.post, url=url, params=params, files=files, **request_params
             )
         else:
             return self._async_request(
@@ -291,9 +286,9 @@ class Api:
         elif "jsonData" not in data:
             return {"json": data}
 
-        assert list(data.keys()) == ["jsonData"], (
-            "jsonData must be the only key in the dictionary."
-        )
+        assert list(data.keys()) == [
+            "jsonData"
+        ], "jsonData must be the only key in the dictionary."
 
         # Content of JSON data should ideally be a string
         content = data["jsonData"]

--- a/tests/api/test_async_api.py
+++ b/tests/api/test_async_api.py
@@ -3,10 +3,8 @@ import pytest
 
 
 class TestAsyncAPI:
-
     @pytest.mark.asyncio
     async def test_async_api(self, native_api):
-
         async with native_api:
             tasks = [native_api.get_info_version() for _ in range(10)]
             responses = await asyncio.gather(*tasks)

--- a/tests/api/test_upload.py
+++ b/tests/api/test_upload.py
@@ -45,6 +45,41 @@ class TestFileUpload:
         # Assert
         assert response.status_code == 200, "File upload failed."
 
+    def test_file_upload_without_metadata(self):
+        """
+        Test case for uploading a file to a dataset without metadata.
+
+        --> json_str will be set as None
+
+        This test case performs the following steps:
+        1. Creates a dataset using the provided metadata.
+        2. Prepares a file for upload.
+        3. Uploads the file to the dataset.
+        4. Asserts that the file upload was successful.
+
+        Raises:
+            AssertionError: If the file upload fails.
+
+        """
+        # Arrange
+        BASE_URL = os.getenv("BASE_URL").rstrip("/")
+        API_TOKEN = os.getenv("API_TOKEN")
+
+        # Create dataset
+        metadata = json.load(open("tests/data/file_upload_ds_minimum.json"))
+        pid = self._create_dataset(BASE_URL, API_TOKEN, metadata)
+        api = NativeApi(BASE_URL, API_TOKEN)
+
+        # Act
+        response = api.upload_datafile(
+            identifier=pid,
+            filename="tests/data/datafile.txt",
+            json_str=None,
+        )
+
+        # Assert
+        assert response.status_code == 200, "File upload failed."
+
     def test_bulk_file_upload(self, create_mock_file):
         """
         Test case for uploading bulk files to a dataset.
@@ -161,9 +196,13 @@ class TestFileUpload:
             replaced_id,
         )
 
-        assert data_file["description"] == "My description.", "Description does not match."
+        assert (
+            data_file["description"] == "My description."
+        ), "Description does not match."
         assert data_file["categories"] == ["Data"], "Categories do not match."
-        assert file_metadata["directoryLabel"] == "some/other", "Directory label does not match."
+        assert (
+            file_metadata["directoryLabel"] == "some/other"
+        ), "Directory label does not match."
         assert response.status_code == 200, "File replacement failed."
         assert (
             replaced_content == mutated
@@ -252,7 +291,6 @@ class TestFileUpload:
         response.raise_for_status()
 
         return response.content.decode("utf-8")
-
 
     @staticmethod
     def _get_file_metadata(

--- a/tests/models/test_datafile.py
+++ b/tests/models/test_datafile.py
@@ -1,4 +1,5 @@
 """Datafile data model tests."""
+
 import json
 import jsonschema
 import os
@@ -244,7 +245,10 @@ class TestDatafileGeneric(object):
             ),
             (({json_upload_min()}, {"validate": False}), object_data_min()),
             (
-                ({json_upload_min()}, {"filename_schema": "wrong", "validate": False},),
+                (
+                    {json_upload_min()},
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 object_data_min(),
             ),
             (
@@ -345,7 +349,10 @@ class TestDatafileGeneric(object):
                 json.loads(json_upload_min()),
             ),
             (
-                (dict_flat_set_min(), {"filename_schema": "wrong", "validate": False},),
+                (
+                    dict_flat_set_min(),
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 json.loads(json_upload_min()),
             ),
             (
@@ -517,7 +524,10 @@ if not os.environ.get("TRAVIS"):
                 ({json_upload_full()}, {}),
                 ({json_upload_min()}, {"data_format": "dataverse_upload"}),
                 ({json_upload_min()}, {"validate": False}),
-                ({json_upload_min()}, {"filename_schema": "wrong", "validate": False},),
+                (
+                    {json_upload_min()},
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 (
                     {json_upload_min()},
                     {
@@ -550,4 +560,6 @@ if not os.environ.get("TRAVIS"):
 
                 for key, val in pdv_end.get().items():
                     assert getattr(pdv_start, key) == getattr(pdv_end, key)
-                assert len(pdv_start.__dict__) == len(pdv_end.__dict__,)
+                assert len(pdv_start.__dict__) == len(
+                    pdv_end.__dict__,
+                )

--- a/tests/models/test_dataset.py
+++ b/tests/models/test_dataset.py
@@ -1,4 +1,5 @@
 """Dataset data model tests."""
+
 import json
 import os
 import platform
@@ -950,11 +951,17 @@ class TestDatasetSpecific(object):
             ),
             (({json_upload_min()}, {"validate": False}), object_data_min()),
             (
-                ({json_upload_min()}, {"filename_schema": "", "validate": False},),
+                (
+                    {json_upload_min()},
+                    {"filename_schema": "", "validate": False},
+                ),
                 object_data_min(),
             ),
             (
-                ({json_upload_min()}, {"filename_schema": "wrong", "validate": False},),
+                (
+                    {json_upload_min()},
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 object_data_min(),
             ),
             (
@@ -995,11 +1002,17 @@ class TestDatasetSpecific(object):
                 json.loads(json_upload_min()),
             ),
             (
-                (dict_flat_set_min(), {"filename_schema": "", "validate": False},),
+                (
+                    dict_flat_set_min(),
+                    {"filename_schema": "", "validate": False},
+                ),
                 json.loads(json_upload_min()),
             ),
             (
-                (dict_flat_set_min(), {"filename_schema": "wrong", "validate": False},),
+                (
+                    dict_flat_set_min(),
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 json.loads(json_upload_min()),
             ),
             (
@@ -1167,7 +1180,10 @@ if not os.environ.get("TRAVIS"):
                 (dict_flat_set_full(), {}),
                 (dict_flat_set_min(), {"data_format": "dataverse_upload"}),
                 (dict_flat_set_min(), {"validate": False}),
-                (dict_flat_set_min(), {"filename_schema": "wrong", "validate": False},),
+                (
+                    dict_flat_set_min(),
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 (
                     dict_flat_set_min(),
                     {
@@ -1180,7 +1196,6 @@ if not os.environ.get("TRAVIS"):
             ]
 
             for data_set, kwargs_from in data:
-
                 kwargs = {}
                 pdv_start = data_object()
                 pdv_start.set(data_set)
@@ -1200,4 +1215,6 @@ if not os.environ.get("TRAVIS"):
 
                 for key, val in pdv_end.get().items():
                     assert getattr(pdv_start, key) == getattr(pdv_end, key)
-                assert len(pdv_start.__dict__) == len(pdv_end.__dict__,)
+                assert len(pdv_start.__dict__) == len(
+                    pdv_end.__dict__,
+                )

--- a/tests/models/test_dataverse.py
+++ b/tests/models/test_dataverse.py
@@ -1,4 +1,5 @@
 """Dataverse data model tests."""
+
 import json
 import jsonschema
 import os
@@ -296,11 +297,17 @@ class TestDataverseGeneric(object):
             ),
             (({json_upload_min()}, {"validate": False}), object_data_min()),
             (
-                ({json_upload_min()}, {"filename_schema": "", "validate": False},),
+                (
+                    {json_upload_min()},
+                    {"filename_schema": "", "validate": False},
+                ),
                 object_data_min(),
             ),
             (
-                ({json_upload_min()}, {"filename_schema": "wrong", "validate": False},),
+                (
+                    {json_upload_min()},
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 object_data_min(),
             ),
             (
@@ -401,11 +408,17 @@ class TestDataverseGeneric(object):
                 json.loads(json_upload_min()),
             ),
             (
-                (dict_flat_set_min(), {"filename_schema": "", "validate": False},),
+                (
+                    dict_flat_set_min(),
+                    {"filename_schema": "", "validate": False},
+                ),
                 json.loads(json_upload_min()),
             ),
             (
-                (dict_flat_set_min(), {"filename_schema": "wrong", "validate": False},),
+                (
+                    dict_flat_set_min(),
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 json.loads(json_upload_min()),
             ),
             (
@@ -583,8 +596,14 @@ if not os.environ.get("TRAVIS"):
                 ({json_upload_full()}, {}),
                 ({json_upload_min()}, {"data_format": "dataverse_upload"}),
                 ({json_upload_min()}, {"validate": False}),
-                ({json_upload_min()}, {"filename_schema": "", "validate": False},),
-                ({json_upload_min()}, {"filename_schema": "wrong", "validate": False},),
+                (
+                    {json_upload_min()},
+                    {"filename_schema": "", "validate": False},
+                ),
+                (
+                    {json_upload_min()},
+                    {"filename_schema": "wrong", "validate": False},
+                ),
                 (
                     {json_upload_min()},
                     {
@@ -614,4 +633,6 @@ if not os.environ.get("TRAVIS"):
 
                 for key, val in pdv_end.get().items():
                     assert getattr(pdv_start, key) == getattr(pdv_end, key)
-                assert len(pdv_start.__dict__) == len(pdv_end.__dict__,)
+                assert len(pdv_start.__dict__) == len(
+                    pdv_end.__dict__,
+                )

--- a/tests/models/test_dvobject.py
+++ b/tests/models/test_dvobject.py
@@ -1,4 +1,5 @@
 """Dataverse data model tests."""
+
 from pyDataverse.models import DVObject
 
 


### PR DESCRIPTION
**Overview**

This PR addresses the issue reported at https://github.com/datalad/datalad-dataverse/issues/320, where metadata sent via NativeApi.replace_datafile wasn’t updating the file metadata correctly. The problem arose because the jsonData payload needs to be sent as form-data, which HTTPX’s json kwarg doesn’t handle properly.

The fix involves sending the payload via the data argument. However, since other endpoints require data to be sent through the json argument, this PR introduces a private method in api.py to determine the correct way to send the data. This method checks for the presence of the jsonData key and adjusts the argument accordingly. If the key isn’t found, the json argument is used by default.

To prevent similar issues in the future, the tests have been updated. The replace_datafile tests now ensure that the metadata is correctly updated.

**TLDR**

* If `jsonData` key is present sent through `data` kwarg
* If not, JSON payload is sent through `json`
* Extended tests to verify metadata is updated correctly
