### PR TITLE
Remove trailing slash of `base_url` upon `Api` initialization

### DIFF
--- a/pyDataverse/api.py
+++ b/pyDataverse/api.py
@@ -110,7 +110,7 @@ class Api:
         if not isinstance(base_url, str):
             raise ApiUrlError("base_url {0} is not a string.".format(base_url))
 
-        self.base_url = base_url
+        self.base_url = base_url.rstrip("/")
         self.client = None
 
         if not isinstance(api_version, str):


### PR DESCRIPTION
Issue #213 highlighted failing tests within the SWORD API authentication, and the cause was a trailing slash in the `base_url`, which led to a malformed URL. This could be a potential point of frustration for users, as there is no indication that the `base_url` should not end with a slash. Therefore, this PR modifies the `__init__` method of the base `Api` class to automatically strip any trailing slash, so users no longer need to worry about this.

Closes #213 