### PR TITLE
Update `httpx` dependency version range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [{ include = "pyDataverse" }]
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-httpx = "^0.27.0"
+httpx = ">=0.27,<0.30"
 jsonschema = "^4.21.1"
 
 [tool.poetry.group.dev]


### PR DESCRIPTION
This pull request updates the version constraint for the `httpx` dependency in the `pyproject.toml` file to allow for newer patch releases while maintaining compatibility.

Dependency updates:

* Changed the `httpx` dependency version from `^0.27.0` to `>=0.27,<0.30` in `pyproject.toml`, allowing updates up to but not including version 0.30.