### PR TITLE
Fix container tests in `run_tests.sh` use hard-coded `DV_VERSION`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ In order to run the tests, you need to have a Dataverse instance running. We hav
 ./run_tests.sh -p 3.8
 ```
 
-Once finished, you can find the test results in the `dv/unit-tests.log` file and in the terminal.
+Once finished, you can find the test results in the `dv/unit-tests.log` file and in the terminal. The Dataverse logs are saved in the `dv/dataverse-logs.log` file and can be helpful in cases of internal server errors. If you happen to encounter such an error, please share the logs with us at the [Zulip](https://dataverse.zulipchat.com/#narrow/stream/377090-python) so we can investigate the issue.
 
 ## Manual setup
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,16 @@ export $(grep "API_TOKEN" "dv/bootstrap.exposed.env")
 export API_TOKEN_SUPERUSER=$API_TOKEN
 ```
 
-**3. Run the test(s) with pytest**
+**3. Install test dependencies
+
+```
+python3 -m venv venv # or conda create -n pydataverse
+source venv/bin/activate
+pip install -e .
+python3 -m pip install pytest pytest-cov pytest-asyncio tox selenium
+```
+
+**4. Run the test(s) with pytest**
 
 ```bash
 python -m pytest -v

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -1,8 +1,7 @@
-version: "2.4"
 name: pydataverse
 services:
   dataverse:
-    container_name: "dataverse"
+    container_name: 'dataverse'
     hostname: dataverse
     image: ${DATAVERSE_IMAGE}
     restart: on-failure
@@ -18,7 +17,7 @@ services:
         -Ddataverse.pid.fake.authority=10.5072
         -Ddataverse.pid.fake.shoulder=FK2/
     ports:
-      - "8080:8080"
+      - '8080:8080'
     networks:
       - dataverse
     depends_on:
@@ -45,18 +44,18 @@ services:
       timeout: 240s
 
   dv_initializer:
-    container_name: "dv_initializer"
+    container_name: 'dv_initializer'
     image: ${CONFIGBAKER_IMAGE}
-    restart: "no"
+    restart: 'no'
     command:
       - sh
       - -c
-      - "fix-fs-perms.sh dv"
+      - 'fix-fs-perms.sh dv'
     volumes:
       - ${PWD}/dv/data:/dv
 
   postgres:
-    container_name: "postgres"
+    container_name: 'postgres'
     hostname: postgres
     image: postgres:${POSTGRES_VERSION}
     restart: on-failure
@@ -64,49 +63,49 @@ services:
       - POSTGRES_USER=${DATAVERSE_DB_USER}
       - POSTGRES_PASSWORD=${DATAVERSE_DB_PASSWORD}
     ports:
-      - "5432:5432"
+      - '5432:5432'
     networks:
       - dataverse
 
   solr_initializer:
-    container_name: "solr_initializer"
+    container_name: 'solr_initializer'
     image: ${CONFIGBAKER_IMAGE}
-    restart: "no"
+    restart: 'no'
     command:
       - sh
       - -c
-      - "fix-fs-perms.sh solr && cp -a /template/* /solr-template"
+      - 'fix-fs-perms.sh solr && cp -a /template/* /solr-template'
     volumes:
       - ${PWD}/solr/data:/var/solr
       - ${PWD}/solr/conf:/solr-template
 
   solr:
-    container_name: "solr"
-    hostname: "solr"
+    container_name: 'solr'
+    hostname: 'solr'
     image: solr:${SOLR_VERSION}
     depends_on:
       solr_initializer:
         condition: service_completed_successfully
     restart: on-failure
     ports:
-      - "8983:8983"
+      - '8983:8983'
     networks:
       - dataverse
     command:
-      - "solr-precreate"
-      - "collection1"
-      - "/template"
+      - 'solr-precreate'
+      - 'collection1'
+      - '/template'
     volumes:
       - ${PWD}/solr/data:/var/solr
       - ${PWD}/solr/conf:/template
 
   smtp:
-    container_name: "smtp"
-    hostname: "smtp"
+    container_name: 'smtp'
+    hostname: 'smtp'
     image: maildev/maildev:2.0.5
     restart: on-failure
     expose:
-      - "25" # smtp server
+      - '25' # smtp server
     environment:
       - MAILDEV_SMTP_PORT=25
       - MAILDEV_MAIL_DIRECTORY=/mail
@@ -116,10 +115,10 @@ services:
       - /mail:mode=770,size=128M,uid=1000,gid=1000
 
   bootstrap:
-    container_name: "bootstrap"
-    hostname: "bootstrap"
+    container_name: 'bootstrap'
+    hostname: 'bootstrap'
     image: ${CONFIGBAKER_IMAGE}
-    restart: "no"
+    restart: 'no'
     networks:
       - dataverse
     volumes:
@@ -127,7 +126,7 @@ services:
     command:
       - sh
       - -c
-      - "bootstrap.sh -e /.env dev"
+      - 'bootstrap.sh -e /.env dev'
     depends_on:
       dataverse:
         condition: service_healthy

--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -29,7 +29,6 @@ services:
         condition: service_completed_successfully
     volumes:
       - ${PWD}/dv/data:/dv
-      - ${PWD}:/secrets
     tmpfs:
       - /dumps:mode=770,size=2052M,uid=1000,gid=1000
       - /tmp:mode=770,size=2052M,uid=1000,gid=1000

--- a/docker/docker-compose-test-all.yml
+++ b/docker/docker-compose-test-all.yml
@@ -8,7 +8,7 @@ services:
       - dataverse
     volumes:
       - ${PWD}:/pydataverse
-      - ../dv:/dv
+      - ${PWD}/dv:/dv
     command:
       - sh
       - -ceu

--- a/docker/docker-compose-test-all.yml
+++ b/docker/docker-compose-test-all.yml
@@ -1,11 +1,9 @@
-version: "2.4"
 services:
   unit-tests:
     container_name: unit-tests
     image: python:${PYTHON_VERSION}-slim
     environment:
       BASE_URL: http://dataverse:8080
-      DV_VERSION: 6.3
     networks:
       - dataverse
     volumes:
@@ -13,18 +11,39 @@ services:
       - ../dv:/dv
     command:
       - sh
-      - -c
+      - -ceu
       - |
+        set -o pipefail
+
+        # Install curl
+        apt-get update && apt-get install -y curl
+
+        # Wait for Dataverse to be ready
+        echo "⏳ Waiting for Dataverse to be ready..."
+        until curl -f http://dataverse:8080/api/info/version >/dev/null 2>&1; do
+          echo "   Waiting for Dataverse API..."
+          sleep 5
+        done
+        echo "✅ Dataverse is ready!"
+
+        # Fetch Dataverse version dynamically
+        echo "🔍 Fetching Dataverse version..."
+        export DV_VERSION=$$(curl -s http://dataverse:8080/api/info/version | grep -o '"version":"[^"]*"' | cut -d'"' -f4)
+        echo "   Detected Dataverse version: $$DV_VERSION"
+
         # Fetch the API Token from the local file
-        export $(grep "API_TOKEN" "dv/bootstrap.exposed.env")
+        export $$(grep "API_TOKEN" "dv/bootstrap.exposed.env")
         export API_TOKEN_SUPERUSER=$$API_TOKEN
+
         cd /pydataverse
 
-        # Run the unit tests
+        # Install Poetry and dependencies
         python3 -m pip install --upgrade pip
-        python3 -m pip install pytest pytest-cov
-        python3 -m pip install -e .
-        python3 -m pytest > /dv/unit-tests.log
+        python3 -m pip install .
+        python3 -m pip install pytest pytest-cov pytest-asyncio tox selenium
+
+        echo "🧪 Starting pytest with DV_VERSION=${DV_VERSION}..."
+        python3 -m pytest -vv --tb=short 2>&1 | tee /dv/unit-tests.log
 
     depends_on:
       bootstrap:

--- a/local-test.env
+++ b/local-test.env
@@ -7,3 +7,6 @@ CONFIGBAKER_IMAGE=docker.io/gdcc/configbaker:unstable
 # Services
 POSTGRES_VERSION=15
 SOLR_VERSION=9.3.0
+
+# Default Dataverse version (will be dynamically detected in tests)
+DV_VERSION=6.7.1

--- a/local-test.env
+++ b/local-test.env
@@ -6,7 +6,7 @@ CONFIGBAKER_IMAGE=docker.io/gdcc/configbaker:unstable
 
 # Services
 POSTGRES_VERSION=15
-SOLR_VERSION=9.3.0
+SOLR_VERSION=9.8.0
 
 # Default Dataverse version (will be dynamically detected in tests)
 DV_VERSION=6.7.1

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -67,12 +67,17 @@ done
 
 # Check if "unit-test" container has failed
 EXIT_CODE=$(docker inspect -f '{{.State.ExitCode}}' unit-tests 2>/dev/null)
+
 if [ -z "$EXIT_CODE" ]; then
     printf "\n❌ Unit tests container not found or failed to start\n"
     EXIT_CODE=1
 else
     printf "\n📋 Unit tests completed with exit code: ${EXIT_CODE}\n"
 fi
+
+# Capture Dataverse logs after tests complete
+printf "\n📝 Capturing Dataverse logs...\n"
+docker logs dataverse > dv/dataverse-logs.log 2>&1
 
 if [ "${EXIT_CODE}" -ne 0 ]; then
     printf "\n❌ Unit tests failed. Showing test results...\n\n"
@@ -84,6 +89,7 @@ if [ "${EXIT_CODE}" -ne 0 ]; then
         docker logs unit-tests
     fi
     printf "\n=== END PYTEST OUTPUT ===\n"
+
     
     printf "\n🧹 Stopping containers...\n"
     docker compose \

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -174,14 +174,22 @@ if not os.environ.get("TRAVIS"):
                 )
             )
             resp = api_su.create_dataset(":root", ds.json())
-            pid = resp.json()["data"]["persistentId"]
-            assert resp.json()["status"] == "OK"
+            resp.raise_for_status()
+
+            resp = resp.json()
+            pid = resp["data"]["persistentId"]
+
+            if resp["status"] != "OK":
+                raise Exception(resp["message"])
 
             # with pytest.raises(ApiAuthorizationError):
             #     resp = api_nru.get_dataset(pid)
 
             resp = api_su.delete_dataset(pid)
-            assert resp.json()["status"] == "OK"
+            resp.raise_for_status()
+            resp = resp.json()
+            if resp["status"] != "OK":
+                raise Exception(resp["message"])
 
         def test_token_should_not_be_exposed_on_error(self):
             BASE_URL = os.getenv("BASE_URL")

--- a/tests/api/test_upload.py
+++ b/tests/api/test_upload.py
@@ -184,7 +184,8 @@ class TestFileUpload:
                 is_filepid=False,
             )
 
-            response.raise_for_status()
+            if not response.ok:
+                raise Exception(response.json()["message"])
 
         # Assert
         file_id = response.json()["data"]["files"][0]["dataFile"]["id"]
@@ -222,6 +223,9 @@ class TestFileUpload:
             json_str=df.json(),
         )
 
+        if not response.ok:
+            raise Exception(response.json()["message"])
+
         # Retrieve file ID
         file_id = response.json()["data"]["files"][0]["dataFile"]["id"]
 
@@ -247,6 +251,9 @@ class TestFileUpload:
                 json_str=json.dumps(json_data),
                 is_filepid=False,
             )
+
+            if not response.ok:
+                raise Exception(response.json()["message"])
 
         # Assert
         file_id = response.json()["data"]["files"][0]["dataFile"]["id"]

--- a/tests/api/test_upload.py
+++ b/tests/api/test_upload.py
@@ -184,7 +184,7 @@ class TestFileUpload:
                 is_filepid=False,
             )
 
-            if not response.ok:
+            if not response.is_success:
                 raise Exception(response.json()["message"])
 
         # Assert
@@ -223,7 +223,7 @@ class TestFileUpload:
             json_str=df.json(),
         )
 
-        if not response.ok:
+        if not response.is_success:
             raise Exception(response.json()["message"])
 
         # Retrieve file ID
@@ -252,7 +252,7 @@ class TestFileUpload:
                 is_filepid=False,
             )
 
-            if not response.ok:
+            if not response.is_success:
                 raise Exception(response.json()["message"])
 
         # Assert

--- a/tests/api/test_upload.py
+++ b/tests/api/test_upload.py
@@ -161,6 +161,8 @@ class TestFileUpload:
             json_str=df.json(),
         )
 
+        response.raise_for_status()
+
         # Retrieve file ID
         file_id = response.json()["data"]["files"][0]["dataFile"]["id"]
 
@@ -181,6 +183,8 @@ class TestFileUpload:
                 json_str=json.dumps(json_data),
                 is_filepid=False,
             )
+
+            response.raise_for_status()
 
         # Assert
         file_id = response.json()["data"]["files"][0]["dataFile"]["id"]


### PR DESCRIPTION
Issue #224 addressed the problem of the local test runner using containers failing due to various reasons. The current implementation hard-coded `DV_VERSION=6.3`, which is not sustainable with newer versions. This PR addresses this issue specifically and also cleans up a couple of other processes in the test chain.

**Testing workflow improvements:**

* The `unit-tests` container now waits for Dataverse to be ready before running tests, dynamically fetches the Dataverse version via its API, and sets the `DV_VERSION` environment variable accordingly. The test startup script also installs required Python dependencies and provides more detailed output during test execution.
* The `run-tests.sh` script has been enhanced to provide clearer progress updates, improved error handling, and more informative output for both successful and failed test runs, including displaying pytest results or container logs as appropriate. [[1]](diffhunk://#diff-50e66c6df89650688e920df8b6ec6b81cf3c32b7eeedb2eda0357b593011228cL47-R88) [[2]](diffhunk://#diff-50e66c6df89650688e920df8b6ec6b81cf3c32b7eeedb2eda0357b593011228cL77-R109)

**Configuration and environment updates:**

* The `local-test.env` file now includes a default `DV_VERSION`, which is overridden by dynamic detection during tests.

**Docker Compose file standardization:**

* All string values in `docker/docker-compose-base.yml` (such as container names, hostnames, ports, commands, and restart policies) have been updated to use single quotes for consistency and to avoid YAML parsing issues. [[1]](diffhunk://#diff-64489f9ac465b36c3b1d98dc7287f38249fd2743f4c8c24dcce0871d531ceaa6L1-R4) [[2]](diffhunk://#diff-64489f9ac465b36c3b1d98dc7287f38249fd2743f4c8c24dcce0871d531ceaa6L21-R20) [[3]](diffhunk://#diff-64489f9ac465b36c3b1d98dc7287f38249fd2743f4c8c24dcce0871d531ceaa6L48-R108) [[4]](diffhunk://#diff-64489f9ac465b36c3b1d98dc7287f38249fd2743f4c8c24dcce0871d531ceaa6L119-R129)

Please note, the test log in #224 provided several other failed tests, but I failed to reproduce these on my machine. Tests pass using the `6.7.1` version. @pdurbin these could be related to other issues we should investigate.

[unit-tests.log](https://github.com/user-attachments/files/22514091/unit-tests.log)