### PR TITLE
Use importlib to set `__version__` and bump to `0.4.0beta1`

### DIFF
--- a/pyDataverse/__init__.py
+++ b/pyDataverse/__init__.py
@@ -8,6 +8,7 @@ Licensed under the MIT License.
 from __future__ import absolute_import
 
 import warnings
+from importlib.metadata import PackageNotFoundError, version
 
 import nest_asyncio
 
@@ -30,10 +31,15 @@ __author__ = "Stefan Kasberger"
 __email__ = "stefan.kasberger@univie.ac.at"
 __copyright__ = "Copyright (c) 2019 Stefan Kasberger"
 __license__ = "MIT License"
-__version__ = "0.3.5"
+
 __url__ = "https://github.com/GDCC/pyDataverse"
 __download_url__ = "https://pypi.python.org/pypi/pyDataverse"
 __description__ = "A Python module for Dataverse."
+
+try:
+    __version__ = version("pyDataverse")
+except PackageNotFoundError:
+    raise RuntimeError("pyDataverse is not installed")
 
 __all__ = [
     "Dataset",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyDataverse"
-version = "0.4.0"
+version = "0.4.0b1"
 description = "A Python module for Dataverse."
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyDataverse"
-version = "0.4.0b1"
+version = "0.4.0beta1"
 description = "A Python module for Dataverse."
 readme = "README.md"
 license = { text = "MIT" }

--- a/uv.lock
+++ b/uv.lock
@@ -1922,7 +1922,7 @@ wheels = [
 
 [[package]]
 name = "pydataverse"
-version = "0.4.0"
+version = "0.4.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "asyncer" },


### PR DESCRIPTION
This pull request updates the versioning approach for the `pyDataverse` package and makes related improvements to how the version is managed and reported. Instead of hardcoding the version in the codebase, it now dynamically retrieves the version from the installed package metadata, and the project version is updated to a beta release.

Version management improvements:

* The `__version__` attribute in `pyDataverse/__init__.py` is now dynamically set using `importlib.metadata.version("pyDataverse")`, ensuring it always reflects the installed package version. If the package is not installed, a `RuntimeError` is raised. [[1]](diffhunk://#diff-fa4818e63b90833bff30cc574878a059d293a0d30a48f1f6824949364ec59a34R11) [[2]](diffhunk://#diff-fa4818e63b90833bff30cc574878a059d293a0d30a48f1f6824949364ec59a34L33-R43)
* The hardcoded version string in `pyDataverse/__init__.py` is removed to avoid inconsistencies with the actual installed version.

Project version update:

* The project version in `pyproject.toml` is updated from `0.4.0` to the beta release `0.4.0beta1`.